### PR TITLE
Enable assertions in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,10 @@ dependencies {
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
 }
 
+run {
+    enableAssertions = true
+}
+
 shadowJar {
     archiveFileName = 'addressbook.jar'
 }


### PR DESCRIPTION
Enable assertions in the build.gradle file.

Fixes #85 